### PR TITLE
Adapt to new version of Maas service

### DIFF
--- a/examples/maas/maas.py
+++ b/examples/maas/maas.py
@@ -32,7 +32,6 @@ def create_task(conn):
         },
         "thread_num": 5,
         "enableKMS": True,
-        "enable_tas": False,
         "dst_node":
         {
             "region": "target_region",

--- a/openstack/maas/v1/task.py
+++ b/openstack/maas/v1/task.py
@@ -56,14 +56,6 @@ class Task(_maasresource.Resource):
     #: Enable KMS
     #: *Type: bool*
     enableKMS = resource.Body('enableKMS', type=bool)
-    #: Enable accelerate
-    #: *Type: bool*
-    enable_tas = resource.Body('enable_tas', type=bool)
-    #: Agent id
-    agent_id = resource.Body('agent_id')
-    #: Agent information only validate when enable_tas is true
-    #: *Type: dict*
-    agent = resource.Body('agent', type=dict)
     #: Taskname
     task_name = resource.Body('task_name')
     #: Task description, empty if user does not set it

--- a/openstack/tests/unit/maas/v1/test_task.py
+++ b/openstack/tests/unit/maas/v1/test_task.py
@@ -32,8 +32,6 @@ EXAMPLE = {
     "progress": 1,
     "migrate_speed": 7213154,
     "enableKMS": True,
-    "enable_tas": False,
-    "agent": {"agent_name": "xxx", "ip": "xxx"},
     "description": "ZXCZCZXCDVXVC",
     "error_reason": {},
     "total_size": 2000000000,
@@ -67,8 +65,6 @@ class TestTask(testtools.TestCase):
         self.assertEqual(EXAMPLE['progress'], sot.progress)
         self.assertEqual(EXAMPLE['migrate_speed'], sot.migrate_speed)
         self.assertEqual(EXAMPLE['enableKMS'], sot.enableKMS)
-        self.assertEqual(EXAMPLE['enable_tas'], sot.enable_tas)
-        self.assertEqual(EXAMPLE['agent'], sot.agent)
         self.assertEqual(EXAMPLE['description'], sot.description)
         self.assertEqual(EXAMPLE['error_reason'], sot.error_reason)
         self.assertEqual(EXAMPLE['total_size'], sot.total_size)


### PR DESCRIPTION
New Maas service changes task's json request body, according to that, remove
following from task resource object.

1. enable_tas
2. agent_id
3. agent