### PR TITLE
RDS/RDS_OS service endpoint hacking

### DIFF
--- a/doc/source/users/guides/rds.rst
+++ b/doc/source/users/guides/rds.rst
@@ -10,11 +10,7 @@ Set environment variable or add these in your application::
 
     os.environ.setdefault(
         'OS_RDS_ENDPOINT_OVERRIDE',
-        'https://rds.eu-de.otc.t-systems.com/rds/v1/%(project_id)s')
+        'https://rds.eu-de.otc.t-systems.com')
 
-RDS service includes OpenStack compatible sdks, these sdks have `os_` prefix,
-to use them, you need to set OS_RDS_ENDPOINT_OVERRIDE as::
-
-    os.environ.setdefault(
-        'OS_RDS_ENDPOINT_OVERRIDE',
-        'https://rds.eu-de.otc.t-systems.com/v1.0/%(project_id)s')
+Please be note that RDS service support 2 modes, for OpenStack compatible mode
+sdks, these sdks have `os_` prefix.

--- a/doc/source/users/guides/rds_os.rst
+++ b/doc/source/users/guides/rds_os.rst
@@ -9,5 +9,5 @@ below.
 Set environment variable or add these in your application::
 
     os.environ.setdefault(
-        'OS_RDS_OS_ENDPOINT_OVERRIDE',
+        'OS_RDS_ENDPOINT_OVERRIDE',
         'https://rds.eu-de.otc.t-systems.com/v1.0/%(project_id)s')

--- a/examples/rds_os/rds_os.py
+++ b/examples/rds_os/rds_os.py
@@ -17,14 +17,8 @@ Managing rds
 
 
 def list_rds_instances(conn):
-    for i in conn.rds.instances():
+    for i in conn.rds.os_instances():
         print(i)
-
-
-def list_rds_flavors(conn):
-    for f in conn.rds.flavors(dbId='87620726-6802-46c0-9028-a8785e1f1922',
-                              region="eu-de"):
-        print(f)
 
 
 def create_instance(conn):
@@ -54,41 +48,99 @@ def create_instance(conn):
         "dbRtPd": "Test@123"
     }
 
-    print(conn.rds.create_instance(**instance_dict))
+    print(conn.rds.os_create_instance(**instance_dict))
 
 
 def get_instance(conn, i):
     """i could be the instance id of an instance object"""
-    return conn.rds.get_instance(i)
-
-
-def set_instance_params(conn, i):
-    """i could be the instance id of an instance object"""
-    params = {
-        "connect_timeout": 17,
-        "sync_binlog": 1
-    }
-    print(conn.rds.set_instance_params(i, **params))
-
-
-def reset_instance_params(conn, i):
-    """i could be the instance id of an instance object"""
-    print(conn.rds.reset_instance_params(i))
-
-
-def list_instance_errorlog(conn, i):
-    """i could be the instance id of an instance object"""
-    for l in conn.rds.list_instance_errorlog(i,
-                                             startDate="2017-07-11+06:35",
-                                             endDate="2017-07-20+06:35"):
-        print(l)
-
-
-def list_instance_slowlog(conn, i):
-    """i could be the instance id of an instance object"""
-    for l in conn.rds.list_instance_slowlog(i, sftype='UPDATE'):
-        print(l)
+    return conn.rds.os_get_instance(i)
 
 
 def get_flavor(conn, f):
-    print(conn.rds.get_flavor(f))
+    print(conn.rds.os_get_flavor(f))
+
+
+def list_rds_flavors(conn):
+    for f in conn.rds.os_flavors(dbId='87620726-6802-46c0-9028-a8785e1f1922',
+                                 region="eu-de"):
+        print(f)
+
+
+def get_parameters(conn, version_id):
+    """list parameters of a datastore"""
+    for p in conn.rds.os_parameters(version_id):
+        print(p)
+
+
+def get_parameter(conn, version_id, name):
+    """Get parameter of a datastore by name"""
+    print(conn.rds.os_get_parameter(version_id, name))
+
+
+def get_instance_default_configuration(conn, instance):
+    print(conn.rds.os_get_instance_default_configuration(instance))
+
+
+def list_configuration_group(conn):
+    for g in conn.rds.os_list_configuration_group():
+        print(g)
+
+
+def create_configuration_group(conn):
+    group_dict = {
+        "configuration": {
+            "name": "configuration_test",
+            "description": "configuration_test",
+            "values": {
+                "max_connections": "10",
+                "autocommit": "OFF"
+            },
+            "datastore": {
+                "type": "mysql",
+                "version": "5.6"
+            }
+        }
+    }
+
+    print(conn.rds.os_create_configuration_group(**group_dict))
+
+
+def get_configuration_group(conn, cg):
+    print(conn.rds.os_get_configuration_group(cg))
+
+
+def delete_configuration_group(conn, group):
+    conn.rds.os_delete_configuration_group(group)
+
+
+def update_configuration_group(conn, cg):
+
+    update_dict = {
+        "configuration": {
+            "name": "configuration_test",
+            "description": "configuration_test",
+            "values": {
+                "max_connections": "10",
+                "autocommit": "OFF"
+            }
+        }
+    }
+
+    print(conn.rds.os_update_configuration_group(cg, **update_dict))
+
+
+def patch_configuration_group(conn, cg):
+    patch_dict = {
+        "configuration": {
+            "values": {
+                "max_connections": "10",
+                "autocommit": "OFF"
+            }
+        }
+    }
+
+    print(conn.rds.os_patch_configuration_group(cg, **patch_dict))
+
+
+def get_configuration_group_associated_instances(conn, cg):
+    print(conn.rds.os_get_configuration_group_associated_instances(cg))

--- a/examples/sample.py
+++ b/examples/sample.py
@@ -81,7 +81,7 @@ def list_metrics():
     }
     metrics = conn.cloud_eye.metrics(**query)
     for metric in metrics:
-        print metric
+        print(metric)
 
 
 def add_metric_data():
@@ -94,7 +94,8 @@ def add_metric_data():
                 "metric_name": "cpu_util"
             },
             "ttl": 604800,
-            "collect_time": get_epoch_time(now - datetime.timedelta(minutes=5)),
+            "collect_time": get_epoch_time(now
+                                           - datetime.timedelta(minutes=5)),
             "value": 60,
             "unit": "%"
         },
@@ -126,7 +127,7 @@ def list_metric_aggr_data():
     # we query for the data add by add_metric_data()
     aggregations = list(conn.cloud_eye.metric_aggregations(**query))
     for aggr in aggregations:
-        print aggr
+        print(aggr)
 
 # visit API
 list_metrics()

--- a/openstack/rds/v1/rdsresource.py
+++ b/openstack/rds/v1/rdsresource.py
@@ -37,6 +37,9 @@ class Resource(resource.Resource):
                                    session.get_project_id(), url)
         return custom_url
 
+    def _get_custom_override(self, endpoint_override):
+        return endpoint_override + self._version_str + "%(project_id)s"
+
     # overwrite resource2._prepare_request as maas requires header
     # to have Content-type
     def _prepare_request(self, requires_id=True, prepend_key=False):
@@ -67,6 +70,8 @@ class Resource(resource.Resource):
         endpoint_override = self.service.get_endpoint_override()
         if endpoint_override is None:
             request.uri = self._get_custom_url(session, request.uri)
+        else:
+            endpoint_override = self._get_custom_override(endpoint_override)
 
         response = session.get(request.uri, endpoint_filter=self.service,
                                endpoint_override=endpoint_override,
@@ -115,6 +120,9 @@ class Resource(resource.Resource):
             endpoint_override = cls.service.get_endpoint_override()
             if endpoint_override is None:
                 uri = cls._get_custom_url(session, uri)
+            else:
+                endpoint_override = cls._get_custom_override(endpoint_override)
+
             resp = session.get(uri, endpoint_filter=cls.service,
                                endpoint_override=endpoint_override,
                                headers={"Content-type": "application/json",
@@ -175,6 +183,9 @@ class Resource(resource.Resource):
                                             prepend_key=prepend_key)
             if endpoint_override is None:
                 request.uri = self._get_custom_url(session, request.uri)
+            else:
+                endpoint_override = self._get_custom_override(
+                    endpoint_override)
 
             response = session.put(request.uri, endpoint_filter=self.service,
                                    endpoint_override=endpoint_override,
@@ -184,6 +195,9 @@ class Resource(resource.Resource):
                                             prepend_key=prepend_key)
             if endpoint_override is None:
                 request.uri = self._get_custom_url(session, request.uri)
+            else:
+                endpoint_override = self._get_custom_override(
+                    endpoint_override)
 
             response = session.post(request.uri, endpoint_filter=self.service,
                                     endpoint_override=endpoint_override,
@@ -220,6 +234,8 @@ class Resource(resource.Resource):
         endpoint_override = self.service.get_endpoint_override()
         if endpoint_override is None:
             request.uri = self._get_custom_url(session, request.uri)
+        else:
+            endpoint_override = self._get_custom_override(endpoint_override)
 
         if self.patch_update:
             response = session.patch(request.uri, endpoint_filter=self.service,
@@ -252,6 +268,8 @@ class Resource(resource.Resource):
         endpoint_override = self.service.get_endpoint_override()
         if endpoint_override is None:
             request.uri = self._get_custom_url(session, request.uri)
+        else:
+            endpoint_override = self._get_custom_override(endpoint_override)
 
         response = session.delete(request.uri, endpoint_filter=self.service,
                                   endpoint_override=endpoint_override,

--- a/openstack/rds_os/v1/rdsresource.py
+++ b/openstack/rds_os/v1/rdsresource.py
@@ -37,6 +37,9 @@ class Resource(resource.Resource):
                                    session.get_project_id(), url)
         return custom_url
 
+    def _get_custom_override(self, endpoint_override):
+        return endpoint_override + self._version_str + "%(project_id)s"
+
     # overwrite resource2._prepare_request as maas requires header
     # to have Content-type
     def _prepare_request(self, requires_id=True, prepend_key=False):
@@ -67,6 +70,8 @@ class Resource(resource.Resource):
         endpoint_override = self.service.get_endpoint_override()
         if endpoint_override is None:
             request.uri = self._get_custom_url(session, request.uri)
+        else:
+            endpoint_override = self._get_custom_override(endpoint_override)
 
         response = session.get(request.uri, endpoint_filter=self.service,
                                endpoint_override=endpoint_override,
@@ -113,6 +118,11 @@ class Resource(resource.Resource):
 
         while more_data:
             endpoint_override = cls.service.get_endpoint_override()
+            if endpoint_override is None:
+                uri = cls._get_custom_url(session, uri)
+            else:
+                endpoint_override = cls._get_custom_override(endpoint_override)
+
             resp = session.get(uri, endpoint_filter=cls.service,
                                endpoint_override=endpoint_override,
                                headers={"Content-type": "application/json",
@@ -176,6 +186,9 @@ class Resource(resource.Resource):
                                             prepend_key=prepend_key)
             if endpoint_override is None:
                 request.uri = self._get_custom_url(session, request.uri)
+            else:
+                endpoint_override = self._get_custom_override(
+                    endpoint_override)
 
             response = session.put(request.uri, endpoint_filter=self.service,
                                    endpoint_override=endpoint_override,
@@ -185,6 +198,9 @@ class Resource(resource.Resource):
                                             prepend_key=prepend_key)
             if endpoint_override is None:
                 request.uri = self._get_custom_url(session, request.uri)
+            else:
+                endpoint_override = self._get_custom_override(
+                    endpoint_override)
 
             response = session.post(request.uri, endpoint_filter=self.service,
                                     endpoint_override=endpoint_override,
@@ -221,6 +237,8 @@ class Resource(resource.Resource):
         endpoint_override = self.service.get_endpoint_override()
         if endpoint_override is None:
             request.uri = self._get_custom_url(session, request.uri)
+        else:
+            endpoint_override = self._get_custom_override(endpoint_override)
 
         if self.patch_update:
             response = session.patch(request.uri, endpoint_filter=self.service,
@@ -253,6 +271,8 @@ class Resource(resource.Resource):
         endpoint_override = self.service.get_endpoint_override()
         if endpoint_override is None:
             request.uri = self._get_custom_url(session, request.uri)
+        else:
+            endpoint_override = self._get_custom_override(endpoint_override)
 
         response = session.delete(request.uri, endpoint_filter=self.service,
                                   endpoint_override=endpoint_override,


### PR DESCRIPTION
RDS/RDS_OS shares same base endpoints, they should using separate service type, but the requirement would like to have they using same service type but endpoint changes according SDK, this patch add ENDPOINT_OVERRIDE hacking.