### PR TITLE
DMS v2: support tag list in consume message API

### DIFF
--- a/examples/dms/dms.py
+++ b/examples/dms/dms.py
@@ -108,6 +108,21 @@ def consume_message(conn, queue):
         print(conn.dms.ack_consumed_message(cm))
 
 
+# Consume message by tag list in queue and group
+def consume_message_with_tags(conn, qui, gid):
+    #qid = '673f8fca-9aa1-4974-8fc5-b0eb1c5f9724'
+    #gid = 'g-a826e437-2e67-46c7-b220-63836b5bb463'
+    params = {
+        'max_msgs': 10,
+        'time_wait': 30,
+        'tags': ['tag1', 'tag2'],
+        'tag_type': 'or'
+    }
+
+    for c in conn.dms.consume_message(qid, gid, **params):
+        print(c)
+
+
 def get_quotas(conn):
 
     for q in conn.dms.quotas():

--- a/openstack/rds/v1/_proxy.py
+++ b/openstack/rds/v1/_proxy.py
@@ -16,7 +16,7 @@ from openstack.rds.v1 import datastore as _datastore
 from openstack.rds.v1 import flavor as _flavor
 from openstack.rds.v1 import instance as _instance
 
-# Notes(eliqiao): for rds_os service type, we reuse rds service type, but keep
+# Notes: for rds_os service type, we reuse rds service type, but keep
 # rds_os resource still in itself folder to make things easy to check/read.
 from openstack.rds_os.v1 import configuration as _os_configuration
 from openstack.rds_os.v1 import datastore as _os_datastore
@@ -368,7 +368,7 @@ class Proxy(proxy2.BaseProxy):
         return self._get(_datastore.Parameter, name,
                          datastore_version_id=datastore_version_id)
 
-    # Notes(eliqiao): Belows are for rds_os proxy, adding os_ prefix.
+    # Notes: Belows are for rds_os proxy, adding os_ prefix.
     def os_instances(self):
         """List instances
 

--- a/openstack/tests/unit/maas/v1/test_proxy.py
+++ b/openstack/tests/unit/maas/v1/test_proxy.py
@@ -39,11 +39,11 @@ class TestMaaSProxy(test_proxy_base2.TestProxyBase):
         self.verify_get(self.proxy.get_task, _task.Task)
 
     def test_start_task(self):
-        # TODO(eliqiao)
+        # TODO
         pass
 
     def test_stop_task(self):
-        # TODO(eliqiao)
+        # TODO
         pass
 
     def test_task_count(self):


### PR DESCRIPTION
There are some API changes, in DMS consume_message API
Adapt this change.

This API is so different from others, it's not a
RESTFUL style, allow user to pass multiple tags as the query parameters
which can not leverage method of session directly.

See examples for how to passing tag list in SDK.

TODO: for non-override endpoint case, don't support tag list yet