### PR TITLE
Fix: Fix tracker delete exception

### DIFF
--- a/openstack/cts/v1/tracker.py
+++ b/openstack/cts/v1/tracker.py
@@ -54,7 +54,7 @@ class Tracker(ctsresource.Resource):
 
         return cls.existing(**resp)
 
-    def delete(self, session):
+    def delete(self, session, params=None, has_body=False):
 
         params = {'tracker_name': self.tracker_name}
 


### PR DESCRIPTION
tracker delete will report exception because the delete method doesn't
have the param of 'has_body'.

tracker resource implements the delete method itself, which inherits from
base class in resource2.py, but the base class was modified by someone
and make code hard to maintain.

This patch fix it from tracker's delete method in resource class.

See the commit for the detail modification of base resource2.py
https://github.com/Huawei/python-openstacksdk/commit/59b0ca81ce233b09ef7e80b5c4e6e2dc6c061c82#diff-2006ca75f51e419c46a10d2947462e66R743